### PR TITLE
Various improvements

### DIFF
--- a/AudioSpectrumVisualizer.py
+++ b/AudioSpectrumVisualizer.py
@@ -26,6 +26,7 @@ from time import time
 import numpy as np
 import matplotlib.pyplot as plt
 from os import mkdir, path, system
+from joblib import Parallel, delayed
 
 
 # Instantiate the parser
@@ -349,11 +350,11 @@ def saveImageSequence(frames):
 		mkdir(DESTINATION)
 	
 	# Save image sequence
-	frameCounter = 0
-	for frame in frames:
-		plt.imsave(str(DESTINATION) + "/" + str(frameCounter) + ".png", frame, cmap='gray')
-		frameCounter += 1
-		printProgressBar(frameCounter, len(frames))
+	Parallel(n_jobs=-1)(delayed(saveFrame)(frames[i], i, len(frames)) for i in range(len(frames)))
+
+def saveFrame(frame, frame_count, num_frames):
+	plt.imsave(str(DESTINATION) + "/" + str(frame_count) + ".png", frame, cmap='gray')
+	printProgressBar(frame_count, num_frames)
 
 
 """

--- a/AudioSpectrumVisualizer.py
+++ b/AudioSpectrumVisualizer.py
@@ -349,6 +349,7 @@ def saveImageSequence(frames):
 	if not path.exists(DESTINATION):
 		mkdir(DESTINATION)
 	
+	# Save image sequence
 	frameCounter = 0
 	for frame in frames:
 		plt.imsave(str(DESTINATION) + "/" + str(frameCounter) + ".png", frame, cmap='gray')

--- a/AudioSpectrumVisualizer.py
+++ b/AudioSpectrumVisualizer.py
@@ -29,7 +29,7 @@ from os import mkdir, path, system
 
 
 # Instantiate the parser
-parser = argparse.ArgumentParser(description="Creates an Image Sequence for the Audio Spectrum of an Audio File.")
+parser = argparse.ArgumentParser(description="Creates an image sequence for the audio spectrum of an audio file.")
 
 # Required positional arguments
 parser.add_argument("filename", type=str,
@@ -39,7 +39,7 @@ parser.add_argument("destination", type=str, nargs='?', default="Image Sequence"
 
 # Optional arguments
 parser.add_argument("-b", "--bins", type=int, default=64,
-					help="Amount of bins (Bars, Points, etc). Default: 64")
+					help="Amount of bins (bars, points, etc). Default: 64")
 
 parser.add_argument("-ht", "--height", type=int, default=540,
 					help="Max height of the bins (height of the images). Default: 540px")
@@ -417,16 +417,20 @@ def full():
 	if(VIDEO == 1):
 		print("Converting image sequence to video.")
 
-		system('ffmpeg -hide_banner -loglevel error -r {} -i "{}/%0d.png" -c:v libx264 -preset ultrafast -crf 16 -y "{}.mp4"'
+		system('ffmpeg -hide_banner -loglevel error -r {} -i "{}/%0d.png" -c:v libx264 -preset ultrafast -crf 16 -pix_fmt yuv420p -y "{}.mp4"'
 			.format(str(FRAMERATE), str(DESTINATION), str(DESTINATION)))
 		
 		processTime = time() - startTime
 		print("Succesfully converted image sequence to video in " + str(format(processTime, ".3f")) + " seconds.")
 
 	if(VIDEOAUDIO == 1):
+		if(args.end == "False"):		#Python reported the END variable as unbound here??? So I had to use args.end to initialise it again
+			END = len(frames)/FRAMERATE
+		else:
+			END = int(args.end)
 		print("Converting image sequence to video (with audio).")
 		
-		system('ffmpeg -hide_banner -loglevel error -r {} -i "{}/%0d.png" -ss {} -i "{}" -t {} -c:v libx264 -preset ultrafast -crf 16 -y "{}.mp4"'
+		system('ffmpeg -hide_banner -loglevel error -r {} -i "{}/%0d.png" -ss {} -i "{}" -t {} -c:v libx264 -preset ultrafast -crf 16 -pix_fmt yuv420p -y "{}.mp4"'
 			.format(str(FRAMERATE), str(DESTINATION), str(START), str(FILENAME), str(END-START), str(DESTINATION)))
 		
 		processTime = time() - startTime

--- a/AudioSpectrumVisualizer.py
+++ b/AudioSpectrumVisualizer.py
@@ -415,24 +415,23 @@ def full():
 	processTime = time() - startTime
 	print("Created and saved Image Sequence in " + str(format(processTime, ".3f")) + " seconds.")
 
-	if(VIDEO == 1):
-		print("Converting image sequence to video.")
-
-		system('ffmpeg -hide_banner -loglevel error -r {} -i "{}/%0d.png" -c:v libx264 -preset ultrafast -crf 16 -pix_fmt yuv420p -y "{}.mp4"'
-			.format(str(FRAMERATE), str(DESTINATION), str(DESTINATION)))
-		
-		processTime = time() - startTime
-		print("Succesfully converted image sequence to video in " + str(format(processTime, ".3f")) + " seconds.")
-
-	if(VIDEOAUDIO == 1):
-		if(args.end == "False"):		#Python reported the END variable as unbound here??? So I had to use args.end to initialise it again
-			END = len(frames)/FRAMERATE
+	if VIDEOAUDIO or VIDEO:
+		flags = '-hide_banner -loglevel error '
+		flags += '-r {} '.format(str(FRAMERATE))
+		flags += '-i "{}/%0d.png" '.format(str(DESTINATION))
+		if VIDEOAUDIO:
+			print("Converting image sequence to video (with audio).")
+			flags += '-i "{}" '.format(str(FILENAME))
+			if(START != 0):
+				flags += '-ss {} '.format(str(START))
+			if(END != "False"):
+				flags += '-t {} '.format(END - START)
 		else:
-			END = int(args.end)
-		print("Converting image sequence to video (with audio).")
+			print("Converting image sequence to video.")
+
+		flags += '-c:v libx264 -preset ultrafast -crf 16 -pix_fmt yuv420p -y "{}.mp4"'.format(str(DESTINATION))
 		
-		system('ffmpeg -hide_banner -loglevel error -r {} -i "{}/%0d.png" -ss {} -i "{}" -t {} -c:v libx264 -preset ultrafast -crf 16 -pix_fmt yuv420p -y "{}.mp4"'
-			.format(str(FRAMERATE), str(DESTINATION), str(START), str(FILENAME), str(END-START), str(DESTINATION)))
+		system('ffmpeg {}'.format(flags))
 		
 		processTime = time() - startTime
 		print("Succesfully converted image sequence to video in " + str(format(processTime, ".3f")) + " seconds.")

--- a/AudioSpectrumVisualizer.py
+++ b/AudioSpectrumVisualizer.py
@@ -352,9 +352,9 @@ def saveImageSequence(frames):
 	# Save image sequence
 	Parallel(n_jobs=-1)(delayed(saveFrame)(frames[i], i, len(frames)) for i in range(len(frames)))
 
-def saveFrame(frame, frame_count, num_frames):
+def saveFrame(frame, frameCount, numFrames):
 	plt.imsave(str(DESTINATION) + "/" + str(frame_count) + ".png", frame, cmap='gray')
-	printProgressBar(frame_count, num_frames)
+	printProgressBar(frameCount, numFrames)
 
 
 """

--- a/AudioSpectrumVisualizer.py
+++ b/AudioSpectrumVisualizer.py
@@ -421,9 +421,9 @@ def full():
 		flags += '-i "{}/%0d.png" '.format(str(DESTINATION))
 		if VIDEOAUDIO:
 			print("Converting image sequence to video (with audio).")
-			flags += '-i "{}" '.format(str(FILENAME))
 			if(START != 0):
 				flags += '-ss {} '.format(str(START))
+			flags += '-i "{}" '.format(str(FILENAME))
 			if(END != "False"):
 				flags += '-t {} '.format(END - START)
 		else:

--- a/AudioSpectrumVisualizer.py
+++ b/AudioSpectrumVisualizer.py
@@ -349,12 +349,11 @@ def saveImageSequence(frames):
 	if not path.exists(DESTINATION):
 		mkdir(DESTINATION)
 	
-	# Save image sequence
-	Parallel(n_jobs=-1)(delayed(saveFrame)(frames[i], i, len(frames)) for i in range(len(frames)))
-
-def saveFrame(frame, frameCount, numFrames):
-	plt.imsave(str(DESTINATION) + "/" + str(frame_count) + ".png", frame, cmap='gray')
-	printProgressBar(frameCount, numFrames)
+	frameCounter = 0
+	for frame in frames:
+		plt.imsave(str(DESTINATION) + "/" + str(frameCounter) + ".png", frame, cmap='gray')
+		frameCounter += 1
+		printProgressBar(frameCounter, len(frames))
 
 
 """

--- a/AudioSpectrumVisualizer.py
+++ b/AudioSpectrumVisualizer.py
@@ -431,7 +431,7 @@ def full():
 
 		flags += '-c:v libx264 -preset ultrafast -crf 16 -pix_fmt yuv420p -y "{}.mp4"'.format(str(DESTINATION))
 		
-		system('ffmpeg {}'.format(flags))
+		system('ffmpeg ' + flags)
 		
 		processTime = time() - startTime
 		print("Succesfully converted image sequence to video in " + str(format(processTime, ".3f")) + " seconds.")

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ Requires the following packages: `numpy`, `audio2numpy`, `matplotlib`, `ffmpeg` 
 
 Open a command line and change into the directory where the program is located. It is easiest to simply copy the audio file into the same directory, however not at all necessary.
 
-To run the program: `python .\AudioSpectrumVisualizer.py <Path to Audio File> <Destination Folder>` (If no destination folder is given, it defaults to `.\Image Sequence` and creates a new folder in the current directory named `Image Sequence`)
+To run the program: `python AudioSpectrumVisualizer.py <Path to Audio File> <Destination Folder>` (If no destination folder is given, it defaults to `.\Image Sequence` and creates a new folder in the current directory named `Image Sequence`)
 
-Example: `python .\AudioSpectrumVisualizer.py '.\Bursty Greedy Spider.mp3' 'Visualizer'`
+Example: `python AudioSpectrumVisualizer.py '.\Bursty Greedy Spider.mp3' 'Visualizer'`
 
 This creates an image sequence for the audio spectrum of`Bursty Greedy Spider.mp3` into a newly created folder named `Visualizer` in the same directory.
 
-Example for when audio and destination directory are not in the same directory as the program : `python .\AudioSpectrumVisualizer.py '.\User\Music\Bursty Greedy Spider.mp3' '.\User\Desktop\Visualizer'`
+Example for when audio and destination directory are not in the same directory as the program : `python AudioSpectrumVisualizer.py '.\User\Music\Bursty Greedy Spider.mp3' '.\User\Desktop\Visualizer'`
 
 
 
@@ -32,7 +32,7 @@ Example for when audio and destination directory are not in the same directory a
 
 `-ht, --height` Height of the image. Default: 540px
 
-`-w, width` Width of the image. Will be overwritten if both bin_width AND bin_spacing is given! Default: 1920px
+`-w, --width` Width of the image. Will be overwritten if both bin_width AND bin_spacing is given! Default: 1920px
 
 ` -bw, --bin_width` Width of the bins. Default: auto (5/6 * width/bins)
 
@@ -42,11 +42,11 @@ Example for when audio and destination directory are not in the same directory a
 
 `-xlog` Scales the X-axis logarithmically to a given base. Default: 1 (Linear Scaling)
 
-`-st, smoothT` Smoothing over past/next \<smoothT> frames (Smoothes bin over time). If smoothT=auto: Automatic smoothing is applied (framerate/15). Default: 0
+`-st, --smoothT` Smoothing over past/next \<smoothT> frames (Smoothes bin over time). If smoothT=auto: Automatic smoothing is applied (framerate/15). Default: 0
 
 `-sy, --smoothY` Smoothing over past/next \<smoothY> bins (Smoothes bin with adjacent bins). If smoothY=auto: Automatic smoothing is applied (bins/32). Default: 0
 
-`-s ,--start` Begins render at \<start> seconds. If start=False: Renders from the start of the sound file. Default: False
+`-s, --start` Begins render at \<start> seconds. If start=False: Renders from the start of the sound file. Default: False
 
 `-e, --end` Ends render at \<end> seconds. If end=False: Renders to the end of the sound file. Default: False
 
@@ -72,10 +72,10 @@ Currently only a white bar chart, however more will be added at a later date!
 
 ## Examples
 
-Default: `python '.\AudioSpectrumVisualizer.py' <Path to Audio File> <Destination Folder>`
+Default: `python AudioSpectrumVisualizer.py <Path to Audio File> <Destination Folder>`
 
 <img src=".\screenshots\default.png" alt="default" style="zoom: 50%;" />
 
-Slim bins: `python '.\AudioSpectrumVisualizer.py' <Path to Audio File> <Destination Folder> -b 128 -bw 5`
+Slim bins: `python AudioSpectrumVisualizer.py <Path to Audio File> <Destination Folder> -b 128 -bw 5`
 
 <img src=".\screenshots\slimBins.png" alt="default" style="zoom: 50%;" />

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # AudioSpectrumVisualizer
 
-Creates a customizable Image Sequence for the Spectrum of an Audio File.
+Creates a customizable image sequence for the spectrum of an audio file.
 
 
 
-## Requirements
+## Dependencies
 
 Requires the following packages: `numpy`, `audio2numpy`, `matplotlib` and `ffmpeg` 
 
@@ -26,9 +26,9 @@ Example for when audio and destination directory are not in the same directory a
 
 ## Optional  arguments
 
-`-h, --help` Opens the standard help message
+`-h, --help` Shows the standard help message
 
-`-b, -bins` Amount of bins (Bars, Points, etc). Default: 64
+`-b, --bins` Amount of bins (bars, points, etc). Default: 64
 
 `-ht, --height` Height of the image. Default: 540px
 
@@ -36,7 +36,7 @@ Example for when audio and destination directory are not in the same directory a
 
 ` -bw, --bin_width` Width of the bins. Default: auto (5/6 * width/bins)
 
-`-bs, --bin_Spacing` Spacing between bins. Default: auto (1/6 * width/bins)
+`-bs, --bin_spacing` Spacing between bins. Default: auto (1/6 * width/bins)
 
 `-fr, --framerate` Framerate of the image sequence (Frames per second). Default: 30fps
 
@@ -54,15 +54,15 @@ Example for when audio and destination directory are not in the same directory a
 
 `-fe, --frequencyEnd` Limits the range of frequencies to \<frequencyEnd>Hz. If frequencyEnd=False: Ends at highest frequency. Default: False
 
-`-v, --video` Additionaly creates a video (.mp4) from image sequence. Default: False"
+`-v, --video` Additionally creates a video (.mp4) from image sequence. Default: False"
 
-`-va, --videoAudio` Additionaly creates a video (.mp4) from image sequence and audio. Default: False"
+`-va, --videoAudio` Additionally creates a video (.mp4) from image sequence and audio. Default: False"
 
 `-ds, --disableSmoothing` Disables all smoothing (smoothT and smoothY). Default: False
 
 
 
-## Stiles
+## Styles
 
 Currently only a white bar chart, however more will be added at a later date!
 
@@ -72,10 +72,10 @@ Currently only a white bar chart, however more will be added at a later date!
 
 ## Examples
 
-Default: `python '.\Audio Spectrum Visualizer.py' <Path to Audio File> <Destination Folder>`
+Default: `python '.\AudioSpectrumVisualizer.py' <Path to Audio File> <Destination Folder>`
 
 <img src=".\screenshots\default.png" alt="default" style="zoom: 50%;" />
 
-Slim Bins: `python '.\Audio Spectrum Visualizer.py' <Path to Audio File> <Destination Folder> -b 128 -bw 5`
+Slim bins: `python '.\AudioSpectrumVisualizer.py' <Path to Audio File> <Destination Folder> -b 128 -bw 5`
 
 <img src=".\screenshots\slimBins.png" alt="default" style="zoom: 50%;" />

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Creates a customizable image sequence for the spectrum of an audio file.
 
 ## Dependencies
 
-Requires the following packages: `numpy`, `audio2numpy`, `matplotlib` and `ffmpeg` 
+Requires the following packages: `numpy`, `audio2numpy`, `matplotlib`, `ffmpeg` and `joblib`
 
 
 


### PR DESCRIPTION
- correct several spelling mistakes, some terms and a few errors in help message and README
- add `-pix_fmt yuv420p` flag to video exports, this allowed me to properly play the video in VLC
- set END appropriately when `-va` is selected. I would have preferred also using END in the condition, but for some reason Python gives an error, claiming that this is not at all set yet...?
- parallelize saving of the image sequence to use all CPU cores