### PR TITLE
Make color names case-insensitive, allow shorthand hex

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ Example for when audio and destination directory are not in the same directory a
 
 `-bgc, --backgroundColor` Color of the background. Ex: ff0000 or red. Default: 000000 (black)
 
-Color names are equal to the named colors supported by HTML and CSS: [Overview of named colors](https://htmlcolorcodes.com/color-names/).
+Color names are equal to the named colors supported by HTML and CSS: [Overview of named colors](https://htmlcolorcodes.com/color-names/).<br>
+Custom colors can be added to the `colors` dictionary in `color.py` in the form of `"<color name>": [R, G, B],`.
 
 
 

--- a/color.py
+++ b/color.py
@@ -1,7 +1,7 @@
 from sys import exit
 
 """
-This dictionary contains all named colors.
+Dictionary that maps colors names to their [R, G, B] values.
 """
 colors = {
 	# No color


### PR DESCRIPTION
- makes color names case-insensitive (so `RED` works just like `red`), just like in CSS[^1]
- adds support for shorthand hex colors (eg. `fff` is shorthand for `ffffff`), just like in CSS[^2]

[^1]: https://www.w3.org/TR/css-color-3/#html4
[^2]: https://www.w3.org/TR/css-color-3/#rgb-color